### PR TITLE
fix(web): replace raw text model input with ModelPicker in PersonaCreatorModal

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1771,6 +1771,7 @@ function App() {
       onAiAssist={handleAiAssist}
       toolProviders={toolProviders}
       toolDefinitions={toolDefinitions}
+      accounts={human?.settings?.accounts ?? []}
       initialData={personaCreatorInitialData}
       generatePersonaPreview={handleGeneratePersonaPreview}
       onUpdate={personaCreatorInitialData?.mode === 'update' ? handlePersonaUpdateFromPreview : undefined}

--- a/web/src/components/EntityEditor/PersonaCreatorModal.tsx
+++ b/web/src/components/EntityEditor/PersonaCreatorModal.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
 import { isReservedPersonaName, RESERVED_PERSONA_NAMES } from '../../../../src/core/types';
-import type { ToolProvider, ToolDefinition } from '../../../../src/core/types';
+import type { ToolProvider, ToolDefinition, ProviderAccount } from '../../../../src/core/types';
 import type { PersonaGenerationResult } from '../../../../src/prompts/generation/types';
 import { PersonaToolsTab } from './tabs/PersonaToolsTab';
+import { ModelPicker } from '../Settings/ModelPicker';
 import { useOverlayClose } from '../../hooks/useOverlayClose';
 
 interface Trait {
@@ -41,6 +42,7 @@ interface PersonaCreatorModalProps {
   onAiAssist?: (systemPrompt: string, userPrompt: string) => Promise<string>;
   toolProviders?: ToolProvider[];
   toolDefinitions?: ToolDefinition[];
+  accounts?: ProviderAccount[];
   initialData?: {
     name?: string;
     description: string;
@@ -61,6 +63,7 @@ export function PersonaCreatorModal({
   onAiAssist,
   toolProviders = [],
   toolDefinitions = [],
+  accounts = [],
   initialData,
   generatePersonaPreview,
   onUpdate,
@@ -709,19 +712,16 @@ export function PersonaCreatorModal({
                     <p className="ei-creator-help-text">
                       Override the default model for this persona
                     </p>
-                    <div className="ei-form-group">
-                      <label className="ei-form-label">Model</label>
-                      <input
-                        type="text"
-                        className="ei-input"
-                        placeholder="e.g., gpt-4, claude-3-opus (leave empty for default)"
-                        value={model}
-                        onChange={(e) => setModel(e.target.value)}
-                      />
-                      <span className="ei-form-hint">
-                        Uses system default if not specified
-                      </span>
-                    </div>
+                    <ModelPicker
+                      id="creator-model-override"
+                      label="Model"
+                      value={model || undefined}
+                      onChange={(modelId) => setModel(modelId ?? '')}
+                      accounts={accounts}
+                      allowEmpty
+                      optionalLabel
+                      hint="Uses system default if not specified."
+                    />
                   </div>
                 )}
               </div>


### PR DESCRIPTION
Closes #53

## What broke

The persona creator modal had a `<input type="text">` for model selection — meaning users could (and did) type display names like `Local LLM` or `openrouter/claude-3-opus` instead of picking from actual configured providers. That string got persisted to `persona.model`, flowed into queue items, and blew up in `resolveModel()` the moment the provider was renamed.

## What changed

**`PersonaCreatorModal.tsx`**
- Swapped the free-text `<input>` for `ModelPicker` (the same dropdown used in `PersonaSettingsTab` and `SettingsModal`)
- Added `accounts?: ProviderAccount[]` prop to the modal interface

**`App.tsx`**
- Threaded `human?.settings?.accounts ?? []` into `PersonaCreatorModal` (same pattern already used for `PersonaEditor` two lines above)

## What didn't change

The queue serialization path itself is fine — it stores whatever `persona.model` contains. The root issue was bad data getting in via the free-text field. Existing personas with display names stored as their model will still need manual correction via the queue manager, but no new bad data can be created after this.

## Audit

Swept the entire web UI for other raw text inputs where `ModelPicker` should be used — this was the only one. `SettingsModal`, `PersonaSettingsTab`, and `PersonaEditor` all use `ModelPicker` correctly. `ProviderEditor` raw text inputs are intentional (configuring model names/API IDs, not selecting them).

## Review guide

The diff is 15 lines across 2 files. `PersonaCreatorModal.tsx` lines 1-6 (imports), 38-68 (props interface + destructuring), and 708-724 (the swap). `App.tsx` adds one prop to the modal invocation.

Hat tip to [@tomsaleeba](https://github.com/tomsaleeba) for being the first non-family user and immediately finding this 😄